### PR TITLE
fix: Add Firestore rules for children subcollection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,7 +43,7 @@ service cloud.firestore {
       let allowedFields = ['name', 'email', 'stars', 'totalPrayers', 'currentStreak',
                            'longestStreak', 'lastPrayerDate', 'familyId', 'isParent',
                            'parentalConsentGiven', 'parentalConsentDate', 'privacyPolicyVersion',
-                           'createdAt', 'updatedAt'];
+                           'createdAt', 'updatedAt', 'children', 'totalStories', 'rank'];
 
       // Ensure only allowed fields are being updated
       let onlyAllowedFields = request.resource.data.keys().hasOnly(allowedFields);
@@ -88,6 +88,21 @@ service cloud.firestore {
       // User's progress subcollection
       match /progress/{docId} {
         allow read, write: if isOwner(userId);
+      }
+
+      // User's children subcollection - parents can manage their children
+      // This is used by the signup flow to add children directly under the parent's user document
+      match /children/{childId} {
+        allow read: if isOwner(userId);
+        allow create: if isOwner(userId) &&
+          // Validate required fields
+          request.resource.data.name is string &&
+          request.resource.data.name.size() > 0 &&
+          request.resource.data.age is number &&
+          request.resource.data.age >= 4 &&
+          request.resource.data.age <= 17;
+        allow update: if isOwner(userId);
+        allow delete: if isOwner(userId);
       }
 
       // User's task completions subcollection (Issue #26)


### PR DESCRIPTION
## Summary
- Added Firestore security rules for `/users/{userId}/children` subcollection
- Fixed the "Missing or insufficient permissions" error when adding children from signup success page
- Updated `allowedFields` to include `children`, `totalStories`, and `rank` fields

## Test Results
All E2E tests now pass:
- ✅ Auth persistence tests (2/2)
- ✅ Add child flow tests (2/2, 1 skipped for unbuilt feature)
- ✅ Login flow tests (3/3)

```
  1 skipped
  7 passed (42.6s)
```

## Changes
- `firestore.rules`: Added children subcollection rules with validation for name (string) and age (4-17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)