### PR TITLE
feat: Add storyBonus to gamification settings

### DIFF
--- a/app/tests/gamification-settings.spec.ts
+++ b/app/tests/gamification-settings.spec.ts
@@ -42,7 +42,25 @@ test.describe('Gamification Settings', () => {
     expect(settings).not.toBeNull();
     expect(settings).toHaveProperty('starsPerPrayer');
     expect(settings).toHaveProperty('streakBonus');
+    expect(settings).toHaveProperty('storyBonus');
     expect(settings).toHaveProperty('maxDailyStars');
+  });
+
+  test('storyBonus value is loaded from Firestore', async ({ page }) => {
+    await page.goto('/app/');
+    await page.waitForLoadState('load');
+
+    // Wait for Firebase and settings to load
+    await page.waitForTimeout(3000);
+
+    // Check that storyBonus is a positive number (default: 15)
+    const storyBonus = await page.evaluate(() => {
+      // @ts-ignore - AppState is a global variable in the app
+      return window.AppState?.gamificationSettings?.storyBonus;
+    });
+
+    expect(typeof storyBonus).toBe('number');
+    expect(storyBonus).toBeGreaterThan(0);
   });
 
   test('starsPerPrayer value is loaded from Firestore', async ({ page }) => {

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -3691,6 +3691,7 @@
                     AppState.gamificationSettings = {
                         starsPerPrayer: 10,
                         streakBonus: 5,
+                        storyBonus: 15,
                         maxDailyStars: 0
                     };
                     console.log('Using default gamification settings');
@@ -3701,6 +3702,7 @@
                 AppState.gamificationSettings = {
                     starsPerPrayer: 10,
                     streakBonus: 5,
+                    storyBonus: 15,
                     maxDailyStars: 0
                 };
             }


### PR DESCRIPTION
## Summary
- Added `storyBonus` field to gamification settings loading
- App now properly loads story bonus value from Firestore (default: 15)
- Enables admin-configured story completion rewards

## Test plan
- [x] Tests written first (TDD)
- [x] All gamification settings tests pass (4/4)
- [x] App config tests still pass (3/3)
- [x] Deployed to Firebase and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)